### PR TITLE
Remove unused flag --group

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
-use argh::FromArgs;
 use argh;
+use argh::FromArgs;
 
 #[derive(FromArgs)]
 /// Lightweight process killer daemon for out-of-memory scenarios
@@ -7,10 +7,6 @@ pub struct CommandLineArgs {
     /// toggles on verbose output
     #[argh(switch, short = 'V')]
     pub verbose: bool,
-
-    /// when set, bustd will kill the victim's entire process group
-    #[argh(switch, short = 'g')]
-    pub group: bool,
 
     /// when set, the process will not be daemonized
     #[argh(switch, short = 'n')]


### PR DESCRIPTION
Behavior is already covered by `--kill_pgroup`